### PR TITLE
Update Bruno Škvorc bio and add missing Croatian translation

### DIFF
--- a/src/locales/en/members.json
+++ b/src/locales/en/members.json
@@ -25,7 +25,7 @@
         "textperson": "Bringing 10 years of crypto research to life through on-chain analysis and data-driven tools. I build on-chain inflation indexes, DeFi insights, and market dashboards that help investors and teams act fast."
         },
         {
-        "textperson": "Bruno Škvorc is founder of RMRK, NFT protocol on Kusama blockchain network."
+        "textperson": "Bruno Škvorc is the founder of Caimeo, where he builds AI tooling for SMB and enterprise. He is a long time hacker and tinkerer in the blockchain and AI space, focused on developer experience and education, which he consults on through his company Bitfalls."
         }
         ]
 }

--- a/src/locales/hr/members.json
+++ b/src/locales/hr/members.json
@@ -23,6 +23,9 @@
         },
         {
             "textperson": "Deset godina istraživanja kriptovaluta pretvara u praktična rješenja kroz on-chain analizu. Gradi on-chain indekse inflacije, uvide u DeFi i nadzorne ploče za tržište koji pomažu investitorima i timovima da brzo donose odluke."
+        },
+        {
+            "textperson": "Bruno Škvorc je osnivač Caimea, gdje gradi AI alate za male, srednje i velike tvrtke. Dugogodišnji je hacker i tinkerer u blockchain i AI prostoru, fokusiran na developer experience i edukaciju, što konzultira kroz svoju tvrtku Bitfalls."
         }
-    ] 
+    ]
 }


### PR DESCRIPTION
## Summary
- Replaces outdated RMRK-focused bio for Bruno Škvorc with a current bio reflecting his work at **Caimeo** (AI tooling for SMB/enterprise) and **Bitfalls**.
- Adds the missing Croatian-language entry for Bruno in `hr/members.json` — the file previously had only 6 board members while `en/members.json` had 7, so Bruno's HR bio was missing entirely.

## Changes
- `src/locales/en/members.json` — updated `upravniOdbor[6].textperson`
- `src/locales/hr/members.json` — added 7th entry under `upravniOdbor`

## Test plan
- [ ] JSON validates (verified locally)
- [ ] Croatian members page renders Bruno's bio
- [ ] English members page shows new bio
- [ ] No layout regressions on /members/

🤖 Generated with [Claude Code](https://claude.com/claude-code)